### PR TITLE
Removes quotes from the serialised metadata.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ travis-ci = { repository = "mockersf/concourse-resource-rs" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 concourse-resource-derive = { path = "concourse-resource-derive", version = "0.1.0" }
+
+[dev-dependencies.serde_with]
+features = ["json"]
+version = "1.11"

--- a/concourse-resource-derive/Cargo.toml
+++ b/concourse-resource-derive/Cargo.toml
@@ -15,5 +15,6 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
-syn = "0.15"
-quote = "0.6"
+quote = "1.0"
+serde_json = "1.0"
+syn = "1.0"

--- a/concourse-resource-derive/src/lib.rs
+++ b/concourse-resource-derive/src/lib.rs
@@ -42,10 +42,17 @@ fn impl_metadata_kv(name: syn::Ident, data_struct: syn::DataStruct) -> TokenStre
         .iter()
         .filter_map(|field| field.ident.as_ref())
         .map(|field_name| {
+            let val = quote! {
+                serde_json::to_string(&self.#field_name).unwrap()
+            };
             quote! {
                 concourse_resource::internal::KV {
                     name: String::from(stringify!(#field_name)),
-                    value: serde_json::to_string(&self.#field_name).unwrap()
+                    value: #val.strip_prefix('"')
+                    .unwrap_or(&#val)
+                    .strip_suffix('"')
+                    .unwrap_or(&#val)
+                    .to_string()
                 }
             }
         })

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,58 @@
+use concourse_resource::{internal::OutOutputKV, IntoMetadataKV};
+
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use serde_with::DisplayFromStr;
+
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, IntoMetadataKV, Clone)]
+pub struct Metadata {
+    pub commit: String,
+    pub author: String,
+    pub url: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub mr_iid: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    pub project_id: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Version {
+    ver: String,
+}
+
+#[test]
+fn test_serialisation() {
+    let v = Version {
+        ver: String::from("1.1"),
+    };
+    let md = Metadata {
+        commit: String::from("commit_sha"),
+        author: String::from("Han Solo"),
+        url: String::from("https://gitlab.com/group/repo"),
+        mr_iid: 1,
+        project_id: 20000,
+    };
+    let output = serde_json::to_string(&OutOutputKV {
+        version: v,
+        metadata: Some(md.into_metadata_kv()),
+    })
+    .expect("error serializing output");
+    println!("{}", output);
+    assert_eq!(output, "{\"version\":{\"ver\":\"1.1\"},\"metadata\":[{\"name\":\"commit\",\"value\":\"commit_sha\"},{\"name\":\"author\",\"value\":\"Han Solo\"},{\"name\":\"url\",\"value\":\"https://gitlab.com/group/repo\"},{\"name\":\"mr_iid\",\"value\":\"1\"},{\"name\":\"project_id\",\"value\":\"20000\"}]}");
+}
+
+#[test]
+fn test_serde_tostring() {
+    let value = String::from("test");
+    assert_eq!(serde_json::to_value(&value).unwrap(), "test");
+    assert_eq!(
+        serde_json::to_string(&value)
+            .unwrap()
+            .strip_prefix('"')
+            .unwrap()
+            .strip_suffix('"')
+            .unwrap(),
+        "test"
+    );
+}


### PR DESCRIPTION
Relates to [issue 3](https://github.com/mockersf/concourse-resource-rs/issues/3)

* Adds a couple of integration tests to ensure it worked, and to figure out how to make it work.
* Updates some dependencies (unnecessary, but I thought I may as well, while I was in there.
* Removes quotes from metadata strings.

Signed-off-by: Paul Saunders <pms1969@gmail.com>